### PR TITLE
bolder and larger selected folder title

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -97,7 +97,7 @@ h1 {
 }
 
 .folderTitle {
-    opacity: 0.85;
+    opacity: 0.80;
     font-weight: bold;
     transition: padding 160ms ease, outline 160ms ease;
 }
@@ -108,6 +108,8 @@ h1 {
 
 .activeFolder {
     opacity: 1;
+    font-size: larger;
+    font-weight: bolder;
 }
 
 #deleteFolderModalName {


### PR DESCRIPTION
Hi @conceptualspace, I've had a minute to analyze your YASD code this morning and fixed something which was bugging me a bit: visually alter the selected folder title, but only slightly so it doesn't break any aesthetic aspect to the menu.

## Before

Here is the actual folder title design (latest version) with the folder "Data & Refs" selected.

![before-Screenshot 2021-12-12 104054](https://user-images.githubusercontent.com/3285430/145719118-ffe2f511-0551-44e8-bb28-eff381e4e11c.jpg)

## After

Here is the Pull Request with the same folder selected.

![after-Screenshot 2021-12-12 104135](https://user-images.githubusercontent.com/3285430/145719120-3b772b17-6f66-42ce-af40-6b2e2b4219db.jpg)

I find it easier to read and the change is subtle.

Cheers!
