### PR TITLE
Add Github Action to Deploy to Web Stores

### DIFF
--- a/.github/workflows/deploy_to_stores.yml
+++ b/.github/workflows/deploy_to_stores.yml
@@ -1,0 +1,17 @@
+on: workflow_dispatch
+
+name: Submit to Web Stores
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Package
+        run: make package
+      - name: Create zips
+        run: make zip
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea*
 .DS_Store
+*-extension/
+*.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+package:
+	cp -r src/ ./firefox-extension
+	cp -r src/ ./edge-extension
+	cp -r src/ ./chrome-extension
+	cat ./chrome-extension/manifest.json | jq 'del(.chrome_settings_overrides, .browser_specific_settings)' | sponge ./chrome-extension/manifest.json
+
+zip:
+	cd firefox-extension; zip -r ../firefox-extension.zip .; cd ..
+	cd chrome-extension; zip -r ../chrome-extension.zip .; cd ..
+	cd edge-extension; zip -r ../edge-extension.zip .; cd ..
+
+clean:
+	rm -rf *-extension/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ package:
 	cp -r src/ ./firefox-extension
 	cp -r src/ ./edge-extension
 	cp -r src/ ./chrome-extension
-	cat ./chrome-extension/manifest.json | jq 'del(.chrome_settings_overrides, .browser_specific_settings)' | sponge ./chrome-extension/manifest.json
+	cat ./chrome-extension/manifest.json | jq 'del(.chrome_settings_overrides, .browser_specific_settings)' > ./chrome-extension/manifest.json.tmp
+	mv ./chrome-extension/manifest.json.tmp ./chrome-extension/manifest.json
 
 zip:
 	cd firefox-extension; zip -r ../firefox-extension.zip .; cd ..


### PR DESCRIPTION
Hey @conceptualspace, we made a Github action to make it easier to deploy to each of the web stores. This PR integrates YASD's browser extension to our Github action so you can deploy directly from the Github UI.

Currently supporting Chrome, Firefox, Edge, and Opera (Safari support coming soon too)

To facilitate this, I created a Makefile for the project and used `jq` to remove the keys not relevant to Chrome from the Chrome specific folder.

The only thing you would need to create is a `SUBMIT_KEYS` GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json).

Here's a sample key (added the correct zip locations for chrome and firefox here):

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "zip": "./chrome-extension.zip",
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./firefox-extension.zip",
    "apiKey": "123",
    "apiSecret": "abcd",
    "extId": "foobar"
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!