### PR TITLE
Use traditional "New Tab" title

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -159,5 +159,8 @@
   },
   "wallpaper": {
     "message": "Wallpaper"
+  },
+  "newTabTitle": {
+    "message": "New Tab"
   }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -159,5 +159,8 @@
   },
   "wallpaper": {
     "message": "Фоновое изображение\n"
+  },
+  "newTabTitle": {
+    "message": "Новая вкладка"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 
 <head>
-    <title>Speed Dial</title>
+    <title data-locale="newTabTitle">New Tab</title>
     <meta charset="utf-8">
     <meta content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width"
           name="viewport">


### PR DESCRIPTION
Currently the new tab title is fixed at "Speed Dial". Personally I prefer a new tab being called a new tab, that's also how it is in Speed Dial 2.

This PR replaces the text with "New Tab" and adds data-locale attribute for further localization. Includes russian translation.